### PR TITLE
0.2.0 Use httpd.env for httpd server name, alias, app path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 redux-httpd/certificates/*
+redux-httpd/*.env
 redux-mariadb/*.env
 db-data/*
 www-data/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 0.2.0
+- Use redux-httpd/httpd.env for dynamic server name, alias and app path config
+
 # Version 0.1.2
 - Fix deployment of php gd module.
 - Set default php.ini production file on php-fpm configuration.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ First you need to set up a host machine with docker and docker compose (go to ht
  * Ensure your application folder (e.g. `/synapp`) is present on `www-data` folder, build and configured as described on [the app's main repo][4].
  * Ensure your server public certificate, private key, and ca-bundle are present on `redux-httpd/certificates` folder
  * Make sure `/redux-mariadb/mariadb.env` is created and populated with the env vars defined on `/redux-mariadb/mariadb.env.template`
+ * Make sure `/redux-httpd/httpd.env` is created and populated with the env vars defined on `/redux-httpd/httpd.env.template`
 
 When all of the above is done, deploy using `docker-compose up`.
 
 
 ## Change Log
 
- * 0.1.0 - First public release
+ * See [CHANGELOG.md](CHANGELOG.md)
 
 ## Known Issues
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
             - ./www-data:/usr/local/apache2/htdocs
         links:
             - 'redux-php-fpm'
+        env_file:
+            - ./redux-httpd/httpd.env
 
     redux-php-fpm:
         image: redux-php-fpm:latest

--- a/redux-httpd/httpd-ssl.conf
+++ b/redux-httpd/httpd-ssl.conf
@@ -121,13 +121,16 @@ SSLSessionCacheTimeout  300
 ##
 ## SSL Virtual Host Context
 ##
+PassEnv HTTPD_SERVER_NAME
+PassEnv HTTPD_SERVER_ALIAS
+PassEnv HTTPD_APP_RELATIVE_PATH
 NameVirtualHost *:443
 <VirtualHost *:443>
-DocumentRoot "/usr/local/apache2/htdocs/synapp"
-ServerName synapp.info:443
-ServerAlias www.synapp.info:443 *.synapp.info:443
-ErrorLog logs/synapp.info-ssl_error_log
-TransferLog logs/synapp.info-ssl_access_log
+DocumentRoot "/usr/local/apache2/htdocs/${HTTPD_APP_RELATIVE_PATH}"
+ServerName ${HTTPD_SERVER_NAME}:443
+ServerAlias ${HTTPD_SERVER_ALIAS}:443
+ErrorLog logs/${HTTPD_SERVER_NAME}-ssl_error_log
+TransferLog logs/${HTTPD_SERVER_NAME}-ssl_access_log
 LogLevel warn
 SSLEngine on
 SSLProtocol all -SSLv2
@@ -135,7 +138,7 @@ SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
 SSLCertificateFile /usr/local/apache2/conf/server.crt
 SSLCertificateKeyFile /usr/local/apache2/conf/server.pem
 SSLCertificateChainFile /usr/local/apache2/conf/server.ca-bundle
-ProxyPassMatch ^/(.*\.(php|phtml)(/.*)?)$ fcgi://redux-php-fpm:9000/usr/local/apache2/htdocs/synapp/$1
+ProxyPassMatch ^/(.*\.(php|phtml)(/.*)?)$ fcgi://redux-php-fpm:9000/usr/local/apache2/htdocs/${HTTPD_APP_RELATIVE_PATH}/$1
 DirectoryIndex /index.php index.php
 <Files ~ "\.(cgi|shtml|phtml|php3?)$">
     SSLOptions +StdEnvVars
@@ -146,7 +149,7 @@ DirectoryIndex /index.php index.php
 SetEnvIf User-Agent ".*MSIE.*" \
          nokeepalive ssl-unclean-shutdown \
          downgrade-1.0 force-response-1.0
-CustomLog logs/synapp.info-ssl_request_log \
+CustomLog logs/${HTTPD_SERVER_NAME}-ssl_request_log \
           "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 </VirtualHost>
 

--- a/redux-httpd/httpd.conf
+++ b/redux-httpd/httpd.conf
@@ -551,12 +551,15 @@ SSLRandomSeed connect builtin
 
 NameVirtualHost *:80
 Include conf/extra/php.conf
+PassEnv HTTPD_SERVER_NAME
+PassEnv HTTPD_SERVER_ALIAS
+PassEnv HTTPD_APP_RELATIVE_PATH
 <VirtualHost *:80>
-        ServerAdmin webmaster@synapp.info
-        DocumentRoot /usr/local/apache2/htdocs/synapp
-        ServerName synapp.info
-	ServerAlias *.synapp.info
-	Redirect permanent / https://synapp.info/
-        ErrorLog logs/synapp.info-error_log
-        CustomLog logs/synapp.info-access_log common
+        ServerAdmin webmaster@${HTTPD_SERVER_NAME}
+        DocumentRoot /usr/local/apache2/htdocs/${HTTPD_APP_RELATIVE_PATH}
+        ServerName ${HTTPD_SERVER_NAME}
+	ServerAlias ${HTTPD_SERVER_ALIAS}
+	Redirect permanent / https://${HTTPD_SERVER_NAME}/
+        ErrorLog logs/${HTTPD_SERVER_NAME}-error_log
+        CustomLog logs/${HTTPD_SERVER_NAME}-access_log common
 </VirtualHost>

--- a/redux-httpd/httpd.env.template
+++ b/redux-httpd/httpd.env.template
@@ -1,0 +1,3 @@
+HTTPD_SERVER_NAME=synapp.info
+HTTPD_SERVER_ALIAS=*.synapp.info
+HTTPD_APP_RELATIVE_PATH=synapp


### PR DESCRIPTION
0.2.0 - Use redux-httpd/httpd.env for dynamic server name, alias and app path config